### PR TITLE
Corrige compatibilidade com versões do Angular 18 e Angular 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-vlibras",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^20.0.3",
     "@angular/platform-browser-dynamic": "^20.0.3",
     "@angular/router": "^20.0.3",
-    "angular-vlibras": "^1.0.0",
+    "angular-vlibras": "^1.0.2",
     "nucleus-angular": "^1.0.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.8.0",

--- a/projects/angular-vlibras/package.json
+++ b/projects/angular-vlibras/package.json
@@ -12,8 +12,8 @@
   },
   "public": true,
   "peerDependencies": {
-    "@angular/common": "^19.1.3",
-    "@angular/core": "^19.1.3"
+    "@angular/common": "^18.0.0 || ^19.0.0 || ^20.0.0",
+    "@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/angular-vlibras/package.json
+++ b/projects/angular-vlibras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-vlibras",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A library for integrating VLibras into Angular applications.",
   "author": "Lucas Ferreira <lucasferreiralimax@gmail.com>",
   "repository": {


### PR DESCRIPTION
Atualmente a biblioteca nas versões 1.0.0 e 1.0.1 estão restritas ao Angular 19:

- Altera o `peerDependencies` da biblioteca para que na próxima versão 1.0.2 seja possível instalar a biblioteca tanto no Angular 18 quanto no Angular 20

Se possível, @lucasferreiralimax , dá uma revisada, e se aprovado por favor se puder lançar a versão 1.0.2 no NPM ficarei bastante agradecido, obrigado!